### PR TITLE
feat: chapters toggle, two-mode sidebar, and book navigation redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ _fresh/*
 
 # Playwright MCP test artifacts
 .playwright-mcp/
+
+# Git worktrees
+.worktrees/

--- a/client/src/api/books.ts
+++ b/client/src/api/books.ts
@@ -8,13 +8,22 @@ export const booksApi = {
   create: (
     seriesId: string,
     data: Pick<Book, "title"> &
-      Partial<Pick<Book, "author" | "publishDate" | "isbn">>,
+      Partial<Pick<Book, "author" | "publishDate" | "isbn" | "hasChapters">>,
   ) => api.post<Book>(`/api/series/${seriesId}/books`, data),
   update: (
     seriesId: string,
     bookId: string,
     data: Partial<Pick<Book, "title" | "author" | "publishDate" | "isbn">>,
   ) => api.put<Book>(`/api/series/${seriesId}/books/${bookId}`, data),
+  toggleChapters: (
+    seriesId: string,
+    bookId: string,
+    hasChapters: boolean,
+  ) =>
+    api.patch<{ book: Book; scenesFlattened: number; chaptersRemoved: number }>(
+      `/api/series/${seriesId}/books/${bookId}`,
+      { hasChapters },
+    ),
   delete: (seriesId: string, bookId: string) =>
     api.delete<void>(`/api/series/${seriesId}/books/${bookId}`),
 };

--- a/client/src/api/scenes.ts
+++ b/client/src/api/scenes.ts
@@ -10,7 +10,16 @@ export const scenesApi = {
     seriesId: string,
     bookId: string,
     data: { text?: string; chapterId?: string },
-  ) => api.post<Scene>(`/api/series/${seriesId}/books/${bookId}/scenes`, data),
+  ) => {
+    const { chapterId, ...rest } = data;
+    if (chapterId) {
+      return api.post<Scene>(
+        `/api/series/${seriesId}/books/${bookId}/chapters/${chapterId}/scenes`,
+        rest,
+      );
+    }
+    return api.post<Scene>(`/api/series/${seriesId}/books/${bookId}/scenes`, rest);
+  },
   update: (
     seriesId: string,
     bookId: string,

--- a/client/src/components/HierarchicalSceneList.tsx
+++ b/client/src/components/HierarchicalSceneList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   DndContext,
   closestCenter,
@@ -18,14 +18,8 @@ import { CSS } from "@dnd-kit/utilities";
 import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type { Chapter, Scene } from "@/types/story";
+import type { BookItem, Chapter, Scene } from "@/types/story";
 import { rankBetween } from "@/lib/rank";
-
-interface BookItem {
-  type: "chapter" | "scene";
-  id: string;
-  rank: string;
-}
 
 interface HierarchicalSceneListProps {
   seriesId: string;
@@ -48,7 +42,6 @@ interface HierarchicalSceneListProps {
 
 function ChapterRow({
   chapter,
-  index,
   scenes,
   activeSceneId,
   onSelect,
@@ -58,7 +51,6 @@ function ChapterRow({
   onDeleteScene,
 }: {
   chapter: Chapter;
-  index: number;
   scenes: Scene[];
   activeSceneId?: string;
   onSelect: (s: Scene) => void;
@@ -109,6 +101,9 @@ function ChapterRow({
 
       {open && (
         <div className="ml-5 border-l border-white/5 pl-2">
+          {/* NOTE: Scene dragging within chapters is visually wired here, but
+              handleDragEnd in the parent only processes top-level items (chapters or
+              book-level scenes). Intra-chapter scene reordering is NOT yet functional. */}
           <SortableContext
             items={scenes.map((s) => `scene:${s.id}`)}
             strategy={verticalListSortingStrategy}
@@ -178,6 +173,14 @@ function SceneRow({
         }`}
       >
         {title}
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="hidden group-hover:flex items-center justify-center h-4 w-4 rounded text-[10px] text-gray-600 hover:text-gray-400 hover:bg-white/10 transition-colors flex-shrink-0"
+        aria-label="Delete scene"
+      >
+        ×
       </button>
     </div>
   );
@@ -320,6 +323,10 @@ export function HierarchicalSceneList({
   const [showNewChapter, setShowNewChapter] = useState(false);
   const [forcedExpanded, setForcedExpanded] = useState(false);
 
+  useEffect(() => {
+    if (!focusMode) setForcedExpanded(false);
+  }, [focusMode]);
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -398,7 +405,7 @@ export function HierarchicalSceneList({
               items={chapters.map((ch) => `chapter:${ch.id}`)}
               strategy={verticalListSortingStrategy}
             >
-              {chapters.map((chapter, index) => {
+              {chapters.map((chapter) => {
                 const chapterScenes = scenes
                   .filter((s) => s.chapterId === chapter.id)
                   .sort((a, b) => (a.rank < b.rank ? -1 : 1));
@@ -406,7 +413,6 @@ export function HierarchicalSceneList({
                   <ChapterRow
                     key={chapter.id}
                     chapter={chapter}
-                    index={index}
                     scenes={chapterScenes}
                     activeSceneId={activeSceneId}
                     onSelect={onSelectScene}

--- a/client/src/components/HierarchicalSceneList.tsx
+++ b/client/src/components/HierarchicalSceneList.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { Chapter, Scene } from "@/types/story";
@@ -32,298 +32,445 @@ interface HierarchicalSceneListProps {
   bookId: string;
   chapters: Chapter[];
   scenes: Scene[];
+  hasChapters: boolean;
+  focusMode: boolean;
+  activeSceneId?: string;
   onReorder: (items: BookItem[]) => void;
   onCreateChapter: (title: string) => void;
   onCreateScene: (chapterId?: string) => void;
-  onEditScene: (scene: Scene) => void;
-  onDeleteScene: (sceneId: string) => void;
+  onSelectScene: (scene: Scene) => void;
   onEditChapter: (chapter: Chapter) => void;
   onDeleteChapter: (chapterId: string) => void;
+  onDeleteScene: (sceneId: string) => void;
 }
 
-// ── Sortable row ─────────────────────────────────────────────────────────────
+// ── Sortable chapter row ──────────────────────────────────────────────────────
 
-function SortableChapterRow({
+function ChapterRow({
   chapter,
+  index,
   scenes,
+  activeSceneId,
+  onSelect,
   onEdit,
   onDelete,
   onCreateScene,
-  onEditScene,
   onDeleteScene,
 }: {
   chapter: Chapter;
+  index: number;
   scenes: Scene[];
+  activeSceneId?: string;
+  onSelect: (s: Scene) => void;
   onEdit: () => void;
   onDelete: () => void;
   onCreateScene: () => void;
-  onEditScene: (s: Scene) => void;
   onDeleteScene: (id: string) => void;
 }) {
   const [open, setOpen] = useState(true);
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: `chapter:${chapter.id}` });
 
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <div
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-    >
-      <div className="flex items-center gap-2 rounded border border-white/10 bg-gray-800 px-2 py-1.5">
-        <button
-          {...listeners}
+    <div ref={setNodeRef} style={style}>
+      <div className="group flex items-center gap-1 rounded px-1 py-1 hover:bg-white/5">
+        <span
           {...attributes}
-          className="cursor-grab touch-none text-gray-500 active:cursor-grabbing"
-          aria-label="Drag to reorder"
+          {...listeners}
+          className="cursor-grab text-gray-600 hover:text-gray-400 active:cursor-grabbing"
         >
           <GripVertical className="h-3.5 w-3.5" />
-        </button>
+        </span>
         <button
+          type="button"
           onClick={() => setOpen((v) => !v)}
-          className="flex-1 text-left text-[11px] font-medium text-white"
+          className="flex flex-1 items-center gap-1 text-left"
         >
-          {open ? "▾" : "▸"} {chapter.title}
+          {open ? (
+            <ChevronDown className="h-3 w-3 flex-shrink-0 text-gray-500" />
+          ) : (
+            <ChevronRight className="h-3 w-3 flex-shrink-0 text-gray-500" />
+          )}
+          <span className="truncate text-[11px] font-semibold text-gray-200">
+            {chapter.title}
+          </span>
+          {!open && (
+            <span className="ml-auto text-[10px] text-gray-600">
+              {scenes.length}
+            </span>
+          )}
         </button>
-        <Button size="sm" variant="ghost" onClick={onCreateScene}>
-          <Plus className="h-3.5 w-3.5" />
-          Scene
-        </Button>
-        <Button size="sm" variant="ghost" onClick={onEdit}>
-          <Pencil className="h-3.5 w-3.5" />
-          Edit
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="text-red-400"
-          onClick={() => {
-            if (confirm(`Delete chapter "${chapter.title}"?`)) onDelete();
-          }}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-          Delete
-        </Button>
       </div>
+
       {open && (
-        <div className="ml-4 mt-0.5 space-y-0.5">
-          {scenes.map((scene) => (
-            <SortableSceneRow
-              key={scene.id}
-              scene={scene}
-              onEdit={() => onEditScene(scene)}
-              onDelete={() => onDeleteScene(scene.id)}
-            />
-          ))}
+        <div className="ml-5 border-l border-white/5 pl-2">
+          <SortableContext
+            items={scenes.map((s) => `scene:${s.id}`)}
+            strategy={verticalListSortingStrategy}
+          >
+            {scenes.map((scene) => (
+              <SceneRow
+                key={scene.id}
+                scene={scene}
+                isActive={scene.id === activeSceneId}
+                onSelect={() => onSelect(scene)}
+                onDelete={() => onDeleteScene(scene.id)}
+              />
+            ))}
+          </SortableContext>
+          <button
+            type="button"
+            onClick={onCreateScene}
+            className="mt-1 w-full rounded border border-dashed border-white/10 py-1 text-center text-[10px] text-gray-600 transition-colors hover:border-white/20 hover:text-gray-400"
+          >
+            + scene
+          </button>
         </div>
       )}
     </div>
   );
 }
 
-function SortableSceneRow({
+// ── Sortable scene row ────────────────────────────────────────────────────────
+
+function SceneRow({
   scene,
-  onEdit,
+  isActive,
+  onSelect,
   onDelete,
 }: {
   scene: Scene;
-  onEdit: () => void;
+  isActive: boolean;
+  onSelect: () => void;
   onDelete: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: `scene:${scene.id}` });
 
-  const title =
-    (scene.derived.title ?? scene.text.split("\n")[0].slice(0, 60)) ||
-    "Untitled";
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const title = scene.derived?.title ?? "Untitled scene";
+
+  return (
+    <div ref={setNodeRef} style={style} className="group flex items-center gap-1">
+      <span
+        {...attributes}
+        {...listeners}
+        className="cursor-grab text-gray-700 hover:text-gray-500 active:cursor-grabbing"
+      >
+        <GripVertical className="h-3 w-3" />
+      </span>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={`flex-1 truncate rounded px-2 py-1 text-left text-[11px] transition-colors ${
+          isActive
+            ? "bg-indigo-500/20 text-indigo-300"
+            : "text-gray-400 hover:bg-white/5 hover:text-gray-200"
+        }`}
+      >
+        {title}
+      </button>
+    </div>
+  );
+}
+
+// ── Focus mode strip ──────────────────────────────────────────────────────────
+
+function FocusStrip({
+  chapters,
+  scenes,
+  hasChapters,
+  activeSceneId,
+  onExpand,
+}: {
+  chapters: Chapter[];
+  scenes: Scene[];
+  hasChapters: boolean;
+  activeSceneId?: string;
+  onExpand: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  const activeChapterIndex = hasChapters
+    ? chapters.findIndex((ch) =>
+        scenes.some((s) => s.id === activeSceneId && s.chapterId === ch.id)
+      )
+    : -1;
 
   return (
     <div
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      className="flex items-center gap-2 rounded border border-transparent px-2 py-1 hover:bg-gray-800/60"
+      className="relative flex h-full flex-col items-center gap-2 py-3"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      <button
-        {...listeners}
-        {...attributes}
-        className="cursor-grab touch-none text-gray-500 active:cursor-grabbing"
-        aria-label="Drag to reorder"
+      {hovered && (
+        <button
+          type="button"
+          onClick={onExpand}
+          className="absolute inset-0 z-10 cursor-pointer"
+          aria-label="Return to navigation"
+        />
+      )}
+      {hasChapters
+        ? chapters.map((ch, i) => (
+            <div
+              key={ch.id}
+              className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded text-[10px] font-semibold transition-opacity ${
+                i === activeChapterIndex
+                  ? "bg-indigo-500/30 text-indigo-300 opacity-100"
+                  : "bg-white/5 text-gray-600 opacity-40"
+              }`}
+            >
+              {i + 1}
+            </div>
+          ))
+        : scenes.map((s, i) => (
+            <div
+              key={s.id}
+              className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-[9px] transition-opacity ${
+                s.id === activeSceneId
+                  ? "bg-indigo-500/30 text-indigo-300 opacity-100"
+                  : "bg-white/5 text-gray-600 opacity-30"
+              }`}
+            >
+              {i + 1}
+            </div>
+          ))}
+      <div
+        className="mt-auto text-[8px] uppercase tracking-widest text-gray-700 opacity-40"
+        style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
       >
-        <GripVertical className="h-3.5 w-3.5" />
-      </button>
-      <span className="flex-1 truncate text-[11px] text-gray-200">{title}</span>
-      <Button size="sm" variant="ghost" onClick={onEdit}>
-        Edit
+        nav
+      </div>
+    </div>
+  );
+}
+
+// ── New chapter form ──────────────────────────────────────────────────────────
+
+function NewChapterForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (title: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (value.trim()) {
+          onSubmit(value.trim());
+          setValue("");
+        }
+      }}
+      className="mt-2 flex gap-1"
+    >
+      <Input
+        autoFocus
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Chapter title"
+        className="h-6 text-[11px]"
+      />
+      <Button type="submit" size="sm" className="h-6 px-2 text-[10px]">
+        Add
       </Button>
       <Button
+        type="button"
+        variant="outline"
         size="sm"
-        variant="ghost"
-        className="text-red-400"
-        onClick={() => {
-          if (confirm("Delete this scene?")) onDelete();
-        }}
+        className="h-6 px-2 text-[10px]"
+        onClick={onCancel}
       >
-        <Trash2 className="h-3.5 w-3.5" />
-        Delete
+        ✕
       </Button>
-    </div>
+    </form>
   );
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function HierarchicalSceneList({
+  seriesId,
+  bookId,
   chapters,
   scenes,
+  hasChapters,
+  focusMode,
+  activeSceneId,
   onReorder,
   onCreateChapter,
   onCreateScene,
-  onEditScene,
-  onDeleteScene,
+  onSelectScene,
   onEditChapter,
   onDeleteChapter,
+  onDeleteScene,
 }: HierarchicalSceneListProps) {
-  const [newChapterTitle, setNewChapterTitle] = useState("");
   const [showNewChapter, setShowNewChapter] = useState(false);
+  const [forcedExpanded, setForcedExpanded] = useState(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  // Build ordered list of items (chapters and book-level scenes) sorted by rank
-  const orderedItems = useMemo(() => {
-    const chapterItems = chapters.map((c) => ({
-      type: "chapter" as const,
-      id: `chapter:${c.id}`,
-      rank: c.rank,
-      data: c,
-    }));
-    const bookScenes = scenes
-      .filter((s) => !s.chapterId)
-      .map((s) => ({
-        type: "scene" as const,
-        id: `scene:${s.id}`,
-        rank: s.rank,
-        data: s,
-      }));
-    return [...chapterItems, ...bookScenes].sort((a, b) =>
-      a.rank < b.rank ? -1 : a.rank > b.rank ? 1 : 0,
-    );
-  }, [chapters, scenes]);
+  const isCollapsed = focusMode && !forcedExpanded;
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
-    const oldIndex = orderedItems.findIndex((i) => i.id === active.id);
-    const newIndex = orderedItems.findIndex((i) => i.id === over.id);
+    const activeId = active.id as string;
+    const overId = over.id as string;
+
+    const chapterItems: BookItem[] = chapters.map((ch) => ({
+      type: "chapter",
+      id: ch.id,
+      rank: ch.rank,
+    }));
+    const bookScenes = scenes.filter((s) => !s.chapterId);
+    const sceneItems: BookItem[] = bookScenes.map((s) => ({
+      type: "scene",
+      id: s.id,
+      rank: s.rank,
+    }));
+
+    const allItems = hasChapters ? chapterItems : sceneItems;
+    const oldIndex = allItems.findIndex((item) => `${item.type}:${item.id}` === activeId);
+    const newIndex = allItems.findIndex((item) => `${item.type}:${item.id}` === overId);
     if (oldIndex === -1 || newIndex === -1) return;
 
-    const newOrder = [...orderedItems];
-    const [moved] = newOrder.splice(oldIndex, 1);
-    newOrder.splice(newIndex, 0, moved);
+    const reordered = [...allItems];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
 
-    // Compute new ranks using fractional indexing
-    const reranked = newOrder.map((item, idx) => {
-      const prevRank = idx > 0 ? newOrder[idx - 1].rank : null;
-      const nextRank =
-        idx < newOrder.length - 1 ? newOrder[idx + 1].rank : null;
-      const newRank =
-        item.id === active.id ? rankBetween(prevRank, nextRank) : item.rank;
-      return { ...item, rank: newRank };
-    });
+    const prevRank = newIndex > 0 ? reordered[newIndex - 1].rank : undefined;
+    const nextRank = newIndex < reordered.length - 1 ? reordered[newIndex + 1].rank : undefined;
+    moved.rank = rankBetween(prevRank ?? null, nextRank ?? null);
 
-    const apiItems = reranked.map((item) => {
-      const [type, id] = item.id.split(":");
-      return { type: type as "chapter" | "scene", id, rank: item.rank };
-    });
+    onReorder(reordered);
+  }
 
-    onReorder(apiItems);
+  if (isCollapsed) {
+    return (
+      <div
+        className="flex h-full w-11 flex-col overflow-hidden border-r border-white/5 bg-[#141420] transition-all duration-200"
+        style={{ scrollbarWidth: "none" }}
+      >
+        <FocusStrip
+          chapters={chapters}
+          scenes={scenes}
+          hasChapters={hasChapters}
+          activeSceneId={activeSceneId}
+          onExpand={() => setForcedExpanded(true)}
+        />
+      </div>
+    );
   }
 
   return (
-    <div className="space-y-1.5">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={orderedItems.map((i) => i.id)}
-          strategy={verticalListSortingStrategy}
+    <div
+      className="flex h-full w-56 flex-col overflow-y-auto border-r border-white/5 bg-[#161625] transition-all duration-200"
+      style={{ scrollbarWidth: "thin", scrollbarColor: "#2a2a4a transparent" }}
+      onMouseLeave={() => {
+        if (focusMode) setForcedExpanded(false);
+      }}
+    >
+      <div className="flex-1 p-2">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
         >
-          {orderedItems.map((item) => {
-            if (item.type === "chapter") {
-              const chapter = item.data as Chapter;
-              return (
-                <SortableChapterRow
-                  key={item.id}
-                  chapter={chapter}
-                  scenes={scenes.filter((s) => s.chapterId === chapter.id)}
-                  onEdit={() => onEditChapter(chapter)}
-                  onDelete={() => onDeleteChapter(chapter.id)}
-                  onCreateScene={() => onCreateScene(chapter.id)}
-                  onEditScene={onEditScene}
-                  onDeleteScene={onDeleteScene}
-                />
-              );
-            }
-            const scene = item.data as Scene;
-            return (
-              <SortableSceneRow
-                key={item.id}
-                scene={scene}
-                onEdit={() => onEditScene(scene)}
-                onDelete={() => onDeleteScene(scene.id)}
+          {hasChapters ? (
+            <SortableContext
+              items={chapters.map((ch) => `chapter:${ch.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              {chapters.map((chapter, index) => {
+                const chapterScenes = scenes
+                  .filter((s) => s.chapterId === chapter.id)
+                  .sort((a, b) => (a.rank < b.rank ? -1 : 1));
+                return (
+                  <ChapterRow
+                    key={chapter.id}
+                    chapter={chapter}
+                    index={index}
+                    scenes={chapterScenes}
+                    activeSceneId={activeSceneId}
+                    onSelect={onSelectScene}
+                    onEdit={() => onEditChapter(chapter)}
+                    onDelete={() => onDeleteChapter(chapter.id)}
+                    onCreateScene={() => onCreateScene(chapter.id)}
+                    onDeleteScene={onDeleteScene}
+                  />
+                );
+              })}
+            </SortableContext>
+          ) : (
+            <SortableContext
+              items={scenes.map((s) => `scene:${s.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              {scenes
+                .filter((s) => !s.chapterId)
+                .sort((a, b) => (a.rank < b.rank ? -1 : 1))
+                .map((scene) => (
+                  <SceneRow
+                    key={scene.id}
+                    scene={scene}
+                    isActive={scene.id === activeSceneId}
+                    onSelect={() => onSelectScene(scene)}
+                    onDelete={() => onDeleteScene(scene.id)}
+                  />
+                ))}
+            </SortableContext>
+          )}
+        </DndContext>
+
+        {hasChapters && (
+          <>
+            {showNewChapter ? (
+              <NewChapterForm
+                onSubmit={(title) => {
+                  onCreateChapter(title);
+                  setShowNewChapter(false);
+                }}
+                onCancel={() => setShowNewChapter(false)}
               />
-            );
-          })}
-        </SortableContext>
-      </DndContext>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowNewChapter(true)}
+                className="mt-2 w-full rounded border border-dashed border-white/10 py-1 text-center text-[10px] text-gray-600 transition-colors hover:border-white/20 hover:text-gray-400"
+              >
+                + chapter
+              </button>
+            )}
+          </>
+        )}
 
-      {/* Actions */}
-      <div className="flex gap-2 pt-1">
-        <Button variant="outline" onClick={() => onCreateScene(undefined)}>
-          <Plus className="h-3.5 w-3.5" />
-          Scene
-        </Button>
-        <Button variant="outline" onClick={() => setShowNewChapter(true)}>
-          <Plus className="h-3.5 w-3.5" />
-          Chapter
-        </Button>
-      </div>
-
-      {showNewChapter && (
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (newChapterTitle) {
-              onCreateChapter(newChapterTitle);
-              setNewChapterTitle("");
-              setShowNewChapter(false);
-            }
-          }}
-          className="flex gap-2 pt-1"
-        >
-          <Input
-            autoFocus
-            placeholder="Chapter title"
-            value={newChapterTitle}
-            onChange={(e) => setNewChapterTitle(e.target.value)}
-            className="flex-1"
-          />
-          <Button type="submit">Add</Button>
-          <Button
+        {!hasChapters && (
+          <button
             type="button"
-            variant="outline"
-            onClick={() => setShowNewChapter(false)}
+            onClick={() => onCreateScene(undefined)}
+            className="mt-2 w-full rounded border border-dashed border-white/10 py-1 text-center text-[10px] text-gray-600 transition-colors hover:border-white/20 hover:text-gray-400"
           >
-            Cancel
-          </Button>
-        </form>
-      )}
+            + scene
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -35,7 +35,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div className={cn("px-2.5 pb-2.5 pt-0", className)} {...props} />;
+  return <div className={cn("px-2.5 py-2.5", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {

--- a/client/src/hooks/use-books.ts
+++ b/client/src/hooks/use-books.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { booksApi } from "@/api/books";
 import type { Book } from "@/types/story";
+import { chaptersKeys, scenesKeys } from "@/hooks/use-book-content";
 
 export const booksKeys = {
   all: (seriesId: string) => ["series", seriesId, "books"] as const,
@@ -66,6 +67,8 @@ export function useToggleChaptersMutation(seriesId: string, bookId: string) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: booksKeys.detail(seriesId, bookId) });
       qc.invalidateQueries({ queryKey: booksKeys.all(seriesId) });
+      qc.invalidateQueries({ queryKey: chaptersKeys.all(seriesId, bookId) });
+      qc.invalidateQueries({ queryKey: scenesKeys.all(seriesId, bookId) });
     },
   });
 }

--- a/client/src/hooks/use-books.ts
+++ b/client/src/hooks/use-books.ts
@@ -29,7 +29,7 @@ export function useCreateBookMutation(seriesId: string) {
   return useMutation({
     mutationFn: (
       data: Pick<Book, "title"> &
-        Partial<Pick<Book, "author" | "publishDate" | "isbn">>,
+        Partial<Pick<Book, "author" | "publishDate" | "isbn" | "hasChapters">>,
     ) => booksApi.create(seriesId, data),
     onSuccess: () =>
       qc.invalidateQueries({ queryKey: booksKeys.all(seriesId) }),
@@ -55,5 +55,17 @@ export function useDeleteBookMutation(seriesId: string) {
     mutationFn: (bookId: string) => booksApi.delete(seriesId, bookId),
     onSuccess: () =>
       qc.invalidateQueries({ queryKey: booksKeys.all(seriesId) }),
+  });
+}
+
+export function useToggleChaptersMutation(seriesId: string, bookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (hasChapters: boolean) =>
+      booksApi.toggleChapters(seriesId, bookId, hasChapters),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: booksKeys.detail(seriesId, bookId) });
+      qc.invalidateQueries({ queryKey: booksKeys.all(seriesId) });
+    },
   });
 }

--- a/client/src/pages/BookDetailPage.tsx
+++ b/client/src/pages/BookDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/hooks/use-book-content";
 import { HierarchicalSceneList } from "@/components/HierarchicalSceneList";
 import type { Scene, Chapter } from "@/types/story";
+import { ApiError } from "@/lib/api";
 
 type EditingScene = Scene & { _isNew?: boolean };
 
@@ -45,9 +46,15 @@ export function BookDetailPage() {
   const [sceneText, setSceneText] = useState("");
   const [focusMode, setFocusMode] = useState(false);
   const [activeSceneId, setActiveSceneId] = useState<string | undefined>();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const [editingChapter, setEditingChapter] = useState<Chapter | null>(null);
   const [chapterTitle, setChapterTitle] = useState("");
+
+  function showError(msg: string) {
+    setErrorMessage(msg);
+    setTimeout(() => setErrorMessage(null), 4000);
+  }
 
   function openNewScene(chapterId?: string) {
     setEditingScene({
@@ -69,18 +76,26 @@ export function BookDetailPage() {
   async function handleSaveScene(e: React.FormEvent) {
     e.preventDefault();
     if (!editingScene) return;
-    if (editingScene._isNew) {
-      await createScene.mutateAsync({
-        text: sceneText,
-        chapterId: editingScene.chapterId,
-      });
-    } else {
-      await updateScene.mutateAsync({
-        sceneId: editingScene.id,
-        data: { text: sceneText },
-      });
+    try {
+      if (editingScene._isNew) {
+        await createScene.mutateAsync({
+          text: sceneText,
+          chapterId: editingScene.chapterId,
+        });
+      } else {
+        await updateScene.mutateAsync({
+          sceneId: editingScene.id,
+          data: { text: sceneText },
+        });
+      }
+      setEditingScene(null);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        showError("Book-level scenes are disabled. Add scenes inside a chapter.");
+      } else {
+        throw err;
+      }
     }
-    setEditingScene(null);
   }
 
   function openEditScene(scene: Scene) {
@@ -106,7 +121,7 @@ export function BookDetailPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-end justify-between border-b border-white/10 px-1 pb-2">
+      <div className={`flex items-end justify-between border-b border-white/10 px-1 pb-2 transition-opacity duration-200 ${focusMode ? "opacity-20" : "opacity-100"}`}>
         <div className="space-y-1">
           <Link
             to={`/series/${seriesId}`}
@@ -144,7 +159,15 @@ export function BookDetailPage() {
           focusMode={focusMode}
           activeSceneId={activeSceneId}
           onReorder={(items) => reorder.mutate(items)}
-          onCreateChapter={(title) => createChapter.mutate({ title })}
+          onCreateChapter={(title) =>
+            createChapter.mutate({ title }, {
+              onError: (err) => {
+                if (err instanceof ApiError && err.status === 409) {
+                  showError("Chapters are disabled for this book. Enable chapters in book settings.");
+                }
+              },
+            })
+          }
           onCreateScene={openNewScene}
           onSelectScene={openEditScene}
           onDeleteScene={(id) => {
@@ -190,6 +213,13 @@ export function BookDetailPage() {
               </form>
             </CardContent>
           </Card>
+        </div>
+      )}
+
+      {/* Error toast */}
+      {errorMessage && (
+        <div className="fixed bottom-4 right-4 z-50 rounded border border-red-500/60 bg-red-600/15 px-3 py-2 text-xs text-red-300 shadow-lg">
+          {errorMessage}
         </div>
       )}
 

--- a/client/src/pages/BookDetailPage.tsx
+++ b/client/src/pages/BookDetailPage.tsx
@@ -43,6 +43,8 @@ export function BookDetailPage() {
 
   const [editingScene, setEditingScene] = useState<EditingScene | null>(null);
   const [sceneText, setSceneText] = useState("");
+  const [focusMode, setFocusMode] = useState(false);
+  const [activeSceneId, setActiveSceneId] = useState<string | undefined>();
 
   const [editingChapter, setEditingChapter] = useState<Chapter | null>(null);
   const [chapterTitle, setChapterTitle] = useState("");
@@ -84,6 +86,7 @@ export function BookDetailPage() {
   function openEditScene(scene: Scene) {
     setEditingScene(scene as EditingScene);
     setSceneText(scene.text);
+    setActiveSceneId(scene.id);
   }
 
   function openEditChapter(chapter: Chapter) {
@@ -137,10 +140,13 @@ export function BookDetailPage() {
           bookId={bookId}
           chapters={chapters}
           scenes={scenes}
+          hasChapters={book?.hasChapters !== false}
+          focusMode={focusMode}
+          activeSceneId={activeSceneId}
           onReorder={(items) => reorder.mutate(items)}
           onCreateChapter={(title) => createChapter.mutate({ title })}
           onCreateScene={openNewScene}
-          onEditScene={openEditScene}
+          onSelectScene={openEditScene}
           onDeleteScene={(id) => {
             if (confirm("Delete this scene?")) deleteScene.mutate(id);
           }}
@@ -166,6 +172,8 @@ export function BookDetailPage() {
                   autoFocus
                   value={sceneText}
                   onChange={(e) => setSceneText(e.target.value)}
+                  onFocus={() => setFocusMode(true)}
+                  onBlur={() => setFocusMode(false)}
                   placeholder="Write your scene here... YAML frontmatter supported"
                   className="h-80 font-mono text-[11px]"
                 />

--- a/client/src/pages/BookDetailPage.tsx
+++ b/client/src/pages/BookDetailPage.tsx
@@ -44,6 +44,7 @@ export function BookDetailPage() {
 
   const [editingScene, setEditingScene] = useState<EditingScene | null>(null);
   const [sceneText, setSceneText] = useState("");
+  const [sceneTitle, setSceneTitle] = useState("");
   const [focusMode, setFocusMode] = useState(false);
   const [activeSceneId, setActiveSceneId] = useState<string | undefined>();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -71,6 +72,7 @@ export function BookDetailPage() {
       _isNew: true,
     } as EditingScene);
     setSceneText("");
+    setSceneTitle("");
   }
 
   async function handleSaveScene(e: React.FormEvent) {
@@ -78,8 +80,11 @@ export function BookDetailPage() {
     if (!editingScene) return;
     try {
       if (editingScene._isNew) {
+        const text = sceneTitle.trim()
+          ? `---\ntitle: ${sceneTitle.trim()}\n---\n\n${sceneText}`
+          : sceneText;
         await createScene.mutateAsync({
-          text: sceneText,
+          text,
           chapterId: editingScene.chapterId,
         });
       } else {
@@ -191,8 +196,16 @@ export function BookDetailPage() {
             </CardHeader>
             <CardContent className="pt-2.5">
               <form onSubmit={handleSaveScene} className="space-y-3">
+                {editingScene._isNew && (
+                  <Input
+                    autoFocus
+                    placeholder="Scene title (optional)"
+                    value={sceneTitle}
+                    onChange={(e) => setSceneTitle(e.target.value)}
+                  />
+                )}
                 <Textarea
-                  autoFocus
+                  autoFocus={!editingScene._isNew}
                   value={sceneText}
                   onChange={(e) => setSceneText(e.target.value)}
                   onFocus={() => setFocusMode(true)}

--- a/client/src/pages/BookSettingsPage.tsx
+++ b/client/src/pages/BookSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ChevronLeft, Trash2 } from "lucide-react";
+import { ChevronLeft, Layers, Trash2 } from "lucide-react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,9 @@ import {
   useBookQuery,
   useUpdateBookMutation,
   useDeleteBookMutation,
+  useToggleChaptersMutation,
 } from "@/hooks/use-books";
+import { useChaptersQuery, useScenesQuery } from "@/hooks/use-book-content";
 
 export function BookSettingsPage() {
   const { seriesId = "", bookId = "" } = useParams<{
@@ -20,13 +22,17 @@ export function BookSettingsPage() {
   const navigate = useNavigate();
 
   const { data: book, isLoading } = useBookQuery(seriesId, bookId);
+  const { data: chapters = [] } = useChaptersQuery(seriesId, bookId);
+  const { data: scenes = [] } = useScenesQuery(seriesId, bookId);
   const updateBook = useUpdateBookMutation(seriesId, bookId);
   const deleteBook = useDeleteBookMutation(seriesId);
+  const toggleChapters = useToggleChaptersMutation(seriesId, bookId);
 
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [publishDate, setPublishDate] = useState("");
   const [isbn, setIsbn] = useState("");
+  const [showFlattenModal, setShowFlattenModal] = useState(false);
 
   useEffect(() => {
     if (book) {
@@ -48,6 +54,22 @@ export function BookSettingsPage() {
     navigate(`/series/${seriesId}`);
   }
 
+  function handleChaptersToggle() {
+    const currentlyHasChapters = book?.hasChapters !== false;
+    if (currentlyHasChapters) {
+      // Turning off — show confirmation modal
+      setShowFlattenModal(true);
+    } else {
+      // Turning on — no confirmation needed
+      toggleChapters.mutate(true);
+    }
+  }
+
+  async function handleConfirmFlatten() {
+    await toggleChapters.mutateAsync(false);
+    setShowFlattenModal(false);
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center gap-2 py-6">
@@ -58,6 +80,9 @@ export function BookSettingsPage() {
   }
 
   if (!book) return <p className="p-6 text-red-400">Book not found.</p>;
+
+  const hasChapters = book.hasChapters !== false;
+  const chapterSceneCount = scenes.filter((s) => s.chapterId).length;
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">
@@ -88,7 +113,6 @@ export function BookSettingsPage() {
                 required
               />
             </div>
-
             <div className="space-y-1">
               <div className="panel-title">Author</div>
               <Input
@@ -96,7 +120,6 @@ export function BookSettingsPage() {
                 onChange={(e) => setAuthor(e.target.value)}
               />
             </div>
-
             <div className="space-y-1">
               <div className="panel-title">Publish Date</div>
               <Input
@@ -105,12 +128,10 @@ export function BookSettingsPage() {
                 onChange={(e) => setPublishDate(e.target.value)}
               />
             </div>
-
             <div className="space-y-1">
               <div className="panel-title">ISBN</div>
               <Input value={isbn} onChange={(e) => setIsbn(e.target.value)} />
             </div>
-
             <Button type="submit" disabled={updateBook.isPending}>
               {updateBook.isPending ? <Spinner /> : null}
               Save
@@ -118,6 +139,82 @@ export function BookSettingsPage() {
           </form>
         </CardContent>
       </Card>
+
+      <Card>
+        <CardHeader className="border-b border-white/10">
+          <CardTitle className="flex items-center gap-2">
+            <Layers className="h-4 w-4 text-gray-400" />
+            Organization
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-2.5 space-y-3">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="panel-title mb-1">Organize scenes into chapters</div>
+              <p className="text-[11px] text-gray-400 max-w-sm">
+                Chapters group scenes and add page breaks when exporting.
+                {hasChapters
+                  ? ` This book has ${chapters.length} chapter${chapters.length !== 1 ? "s" : ""}.`
+                  : " This book uses a flat scene list."}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleChaptersToggle}
+              disabled={toggleChapters.isPending}
+              className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+                hasChapters ? "bg-indigo-500" : "bg-gray-600"
+              } ${toggleChapters.isPending ? "opacity-50" : ""}`}
+              aria-checked={hasChapters}
+              role="switch"
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition duration-200 ${
+                  hasChapters ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Flatten confirmation modal */}
+      {showFlattenModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-md rounded-lg border border-white/10 bg-gray-900 p-6 shadow-xl">
+            <h2 className="mb-2 text-sm font-semibold text-white">
+              Remove chapters from this book?
+            </h2>
+            <p className="mb-4 text-[11px] text-gray-400 leading-relaxed">
+              This will remove <strong className="text-white">{chapters.length} chapter{chapters.length !== 1 ? "s" : ""}</strong> and
+              move <strong className="text-white">{chapterSceneCount} scene{chapterSceneCount !== 1 ? "s" : ""}</strong> to a flat list.
+            </p>
+            <ul className="mb-4 space-y-1 text-[11px] text-gray-400">
+              <li>✓ All scene text and frontmatter is preserved</li>
+              <li>✓ Scene order is preserved within each chapter</li>
+              <li>⚠ Chapter titles and descriptions will be deleted</li>
+              <li>⚠ Chapters are not restored automatically if you re-enable this setting</li>
+            </ul>
+            <div className="flex gap-3">
+              <Button
+                variant="destructive"
+                onClick={handleConfirmFlatten}
+                disabled={toggleChapters.isPending}
+              >
+                {toggleChapters.isPending ? <Spinner /> : null}
+                Yes, remove chapters
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setShowFlattenModal(false)}
+                disabled={toggleChapters.isPending}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <Card>
         <CardHeader className="border-b border-white/10">

--- a/client/src/pages/BookSettingsPage.tsx
+++ b/client/src/pages/BookSettingsPage.tsx
@@ -12,7 +12,7 @@ import {
   useDeleteBookMutation,
   useToggleChaptersMutation,
 } from "@/hooks/use-books";
-import { useChaptersQuery, useScenesQuery } from "@/hooks/use-book-content";
+import { useChaptersQuery } from "@/hooks/use-book-content";
 
 export function BookSettingsPage() {
   const { seriesId = "", bookId = "" } = useParams<{
@@ -23,7 +23,6 @@ export function BookSettingsPage() {
 
   const { data: book, isLoading } = useBookQuery(seriesId, bookId);
   const { data: chapters = [] } = useChaptersQuery(seriesId, bookId);
-  const { data: scenes = [] } = useScenesQuery(seriesId, bookId);
   const updateBook = useUpdateBookMutation(seriesId, bookId);
   const deleteBook = useDeleteBookMutation(seriesId);
   const toggleChapters = useToggleChaptersMutation(seriesId, bookId);
@@ -66,8 +65,12 @@ export function BookSettingsPage() {
   }
 
   async function handleConfirmFlatten() {
-    await toggleChapters.mutateAsync(false);
-    setShowFlattenModal(false);
+    try {
+      await toggleChapters.mutateAsync(false);
+      setShowFlattenModal(false);
+    } catch {
+      // Keep modal open; TanStack Query's isError state reflects the failure
+    }
   }
 
   if (isLoading) {
@@ -82,7 +85,6 @@ export function BookSettingsPage() {
   if (!book) return <p className="p-6 text-red-400">Book not found.</p>;
 
   const hasChapters = book.hasChapters !== false;
-  const chapterSceneCount = scenes.filter((s) => s.chapterId).length;
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">
@@ -186,8 +188,7 @@ export function BookSettingsPage() {
               Remove chapters from this book?
             </h2>
             <p className="mb-4 text-[11px] text-gray-400 leading-relaxed">
-              This will remove <strong className="text-white">{chapters.length} chapter{chapters.length !== 1 ? "s" : ""}</strong> and
-              move <strong className="text-white">{chapterSceneCount} scene{chapterSceneCount !== 1 ? "s" : ""}</strong> to a flat list.
+              This will remove <strong className="text-white">{chapters.length} chapter{chapters.length !== 1 ? "s" : ""}</strong> and move all contained scenes to a flat list.
             </p>
             <ul className="mb-4 space-y-1 text-[11px] text-gray-400">
               <li>✓ All scene text and frontmatter is preserved</li>

--- a/client/src/pages/SeriesDetailPage.tsx
+++ b/client/src/pages/SeriesDetailPage.tsx
@@ -32,15 +32,17 @@ export function SeriesDetailPage() {
   const [showCreate, setShowCreate] = useState(false);
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
+  const [hasChapters, setHasChapters] = useState(true);
 
   const isFreeTier = !user?.role || user.role === "free";
   const atLimit = isFreeTier && books.length >= 3;
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
-    await createMutation.mutateAsync({ title, author: author || undefined });
+    await createMutation.mutateAsync({ title, author: author || undefined, hasChapters });
     setTitle("");
     setAuthor("");
+    setHasChapters(true);
     setShowCreate(false);
   }
 
@@ -101,6 +103,30 @@ export function SeriesDetailPage() {
                 value={author}
                 onChange={(e) => setAuthor(e.target.value)}
               />
+              <div className="flex items-start gap-3 rounded-md border border-white/10 p-3">
+                <button
+                  type="button"
+                  onClick={() => setHasChapters((v) => !v)}
+                  className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+                    hasChapters ? "bg-indigo-500" : "bg-gray-600"
+                  }`}
+                  aria-checked={hasChapters}
+                  role="switch"
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition duration-200 ${
+                      hasChapters ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+                <div>
+                  <div className="panel-title mb-0.5">Organize scenes into chapters</div>
+                  <p className="text-[11px] text-gray-400">
+                    Chapters group scenes, add descriptions, and control page breaks when exporting.
+                    You can change this later in book settings.
+                  </p>
+                </div>
+              </div>
               <div className="flex flex-wrap gap-3">
                 <Button type="submit" disabled={createMutation.isPending}>
                   {createMutation.isPending ? <Spinner /> : null}

--- a/client/src/types/story.ts
+++ b/client/src/types/story.ts
@@ -26,6 +26,7 @@ export interface Book {
   publishDate?: string;
   isbn?: string;
   coverImage?: AssetImage;
+  hasChapters: boolean;
   createdAt: number;
   updatedAt: number;
 }

--- a/islands/HierarchicalSceneList.tsx
+++ b/islands/HierarchicalSceneList.tsx
@@ -23,6 +23,7 @@ interface Props {
   }>;
   selectedSceneId: string | null;
   selectedChapterId: string | null;
+  hasChapters: boolean;
 }
 
 // Union type for items in the unified list (book-level items only)
@@ -37,6 +38,7 @@ export default function HierarchicalSceneList({
   chapters: initialChapters,
   selectedSceneId,
   selectedChapterId,
+  hasChapters,
 }: Props) {
   // Create unified list of book-level items (chapters and book-level scenes)
   const bookLevelItems: BookLevelItem[] = [];

--- a/routes/api/series/[seriesId]/books.ts
+++ b/routes/api/series/[seriesId]/books.ts
@@ -98,6 +98,9 @@ export const handler: Handlers = {
       ? body.publishDate.trim()
       : undefined;
     const isbn = typeof body.isbn === "string" ? body.isbn.trim() : undefined;
+    const hasChapters = typeof body.hasChapters === "boolean"
+      ? body.hasChapters
+      : true; // default: chapters enabled
 
     let lastRank: string | undefined;
     for await (
@@ -123,6 +126,7 @@ export const handler: Handlers = {
       author,
       publishDate,
       isbn,
+      hasChapters,
       createdAt: now,
       updatedAt: now,
     };

--- a/routes/api/series/[seriesId]/books/[bookId].ts
+++ b/routes/api/series/[seriesId]/books/[bookId].ts
@@ -86,7 +86,7 @@ async function flattenChapters(
 
       const chapterSceneOrderEntryKey = chapterSceneOrderKey(userId, seriesId, bookId, chapterId, sceneRank, sceneId);
 
-      await kv.atomic()
+      const sceneCommit = await kv.atomic()
         .set(sceneEntityKey, updatedScene)
         .set(bookItemOrderKey(userId, seriesId, bookId, newRank), {
           type: "scene" as const,
@@ -94,17 +94,24 @@ async function flattenChapters(
         })
         .delete(chapterSceneOrderEntryKey)
         .commit();
+      if (!sceneCommit.ok) {
+        throw new Error(`Failed to move scene ${sceneId} during flatten`);
+      }
       scenesFlattened++;
     }
 
     // Delete the chapter entity and its bookItemOrder entry
-    await kv.atomic()
+    const chapterCommit = await kv.atomic()
       .delete(chapterKey(userId, seriesId, bookId, chapterId))
       .delete(bookItemOrderKey(userId, seriesId, bookId, chapterRank))
       .commit();
+    if (!chapterCommit.ok) {
+      throw new Error(`Failed to delete chapter ${chapterId} during flatten`);
+    }
   }
 
-  // Update the book entity
+  // Update the book entity — write hasChapters: false last, only after all
+  // scene moves and chapter deletes have committed successfully.
   const updatedBook: Book = {
     ...book,
     hasChapters: false,

--- a/routes/api/series/[seriesId]/books/[bookId].ts
+++ b/routes/api/series/[seriesId]/books/[bookId].ts
@@ -7,7 +7,7 @@ import {
   readJson,
   requireUser,
 } from "@utils/http.ts";
-import type { Book, BookItem, Chapter, Scene } from "@utils/story/types.ts";
+import type { Book, BookItem, Scene } from "@utils/story/types.ts";
 import {
   bookItemOrderKey,
   bookKey,
@@ -55,7 +55,7 @@ async function flattenChapters(
     if (typeof rank === "string") lastBookRank = rank;
   }
 
-  for (const { id: chapterId } of chapterItems) {
+  for (const { rank: chapterRank, id: chapterId } of chapterItems) {
     // Collect scenes in this chapter
     const chapterScenes: Array<{ rank: string; sceneId: string }> = [];
     for await (
@@ -69,7 +69,7 @@ async function flattenChapters(
       chapterScenes.push({ rank, sceneId });
     }
 
-    for (const { sceneId } of chapterScenes) {
+    for (const { rank: sceneRank, sceneId } of chapterScenes) {
       const newRank = lastBookRank ? rankAfter(lastBookRank) : rankInitial();
       lastBookRank = newRank;
 
@@ -84,51 +84,24 @@ async function flattenChapters(
         updatedAt: Date.now(),
       };
 
-      // Find the chapterSceneOrder entry key for this scene
-      let chapterSceneOrderEntryKey: Deno.KvKey | null = null;
-      for await (
-        const entry of kv.list({
-          prefix: ["yawt", "chapterSceneOrder", userId, seriesId, bookId, chapterId],
-        })
-      ) {
-        const entrySceneId = entry.key[entry.key.length - 1] as string;
-        if (entrySceneId === sceneId) {
-          chapterSceneOrderEntryKey = entry.key;
-          break;
-        }
-      }
+      const chapterSceneOrderEntryKey = chapterSceneOrderKey(userId, seriesId, bookId, chapterId, sceneRank, sceneId);
 
-      const op = kv.atomic()
+      await kv.atomic()
         .set(sceneEntityKey, updatedScene)
         .set(bookItemOrderKey(userId, seriesId, bookId, newRank), {
           type: "scene" as const,
           id: sceneId,
-        });
-
-      if (chapterSceneOrderEntryKey) {
-        op.delete(chapterSceneOrderEntryKey);
-      }
-
-      await op.commit();
+        })
+        .delete(chapterSceneOrderEntryKey)
+        .commit();
       scenesFlattened++;
     }
 
     // Delete the chapter entity and its bookItemOrder entry
-    let chapterOrderKey: Deno.KvKey | null = null;
-    for await (
-      const entry of kv.list<BookItem>({
-        prefix: ["yawt", "bookItemOrder", userId, seriesId, bookId],
-      })
-    ) {
-      if (entry.value?.type === "chapter" && entry.value.id === chapterId) {
-        chapterOrderKey = entry.key;
-        break;
-      }
-    }
-
-    const deleteOp = kv.atomic().delete(chapterKey(userId, seriesId, bookId, chapterId));
-    if (chapterOrderKey) deleteOp.delete(chapterOrderKey);
-    await deleteOp.commit();
+    await kv.atomic()
+      .delete(chapterKey(userId, seriesId, bookId, chapterId))
+      .delete(bookItemOrderKey(userId, seriesId, bookId, chapterRank))
+      .commit();
   }
 
   // Update the book entity
@@ -286,6 +259,7 @@ export const handler: Handlers = {
       return badRequest("hasChapters must be a boolean");
     }
 
+    // Treat undefined as true: legacy books created before hasChapters field existed
     const currentHasChapters = entry.value.hasChapters !== false;
     const nextHasChapters = body.hasChapters as boolean;
 

--- a/routes/api/series/[seriesId]/books/[bookId].ts
+++ b/routes/api/series/[seriesId]/books/[bookId].ts
@@ -7,9 +7,140 @@ import {
   readJson,
   requireUser,
 } from "@utils/http.ts";
-import type { Book } from "@utils/story/types.ts";
-import { bookKey, bookOrderKey } from "@utils/story/keys.ts";
+import type { Book, BookItem, Chapter, Scene } from "@utils/story/types.ts";
+import {
+  bookItemOrderKey,
+  bookKey,
+  bookOrderKey,
+  chapterKey,
+  chapterSceneOrderKey,
+  sceneKey,
+} from "@utils/story/keys.ts";
+import { rankAfter, rankInitial } from "@utils/story/rank.ts";
 import { deleteObject, getR2Bucket } from "@utils/r2.ts";
+
+async function flattenChapters(
+  kv: Deno.Kv,
+  userId: number,
+  seriesId: string,
+  bookId: string,
+  book: Book,
+  bookEntityKey: Deno.KvKey,
+): Promise<Response> {
+  // 1. Collect all chapters (in order)
+  const chapterItems: Array<{ rank: string; id: string }> = [];
+  for await (
+    const entry of kv.list<BookItem>({
+      prefix: ["yawt", "bookItemOrder", userId, seriesId, bookId],
+    })
+  ) {
+    if (entry.value?.type === "chapter") {
+      const rankKey = entry.key[entry.key.length - 1] as string;
+      chapterItems.push({ rank: rankKey, id: entry.value.id });
+    }
+  }
+
+  let scenesFlattened = 0;
+  const chaptersRemoved = chapterItems.length;
+
+  // Find the last existing book-level item rank to append after
+  let lastBookRank: string | undefined;
+  for await (
+    const entry of kv.list<BookItem>(
+      { prefix: ["yawt", "bookItemOrder", userId, seriesId, bookId] },
+      { reverse: true, limit: 1 },
+    )
+  ) {
+    const rank = entry.key[entry.key.length - 1] as string;
+    if (typeof rank === "string") lastBookRank = rank;
+  }
+
+  for (const { id: chapterId } of chapterItems) {
+    // Collect scenes in this chapter
+    const chapterScenes: Array<{ rank: string; sceneId: string }> = [];
+    for await (
+      const entry of kv.list({
+        prefix: ["yawt", "chapterSceneOrder", userId, seriesId, bookId, chapterId],
+      })
+    ) {
+      const key = entry.key;
+      const rank = key[key.length - 2] as string;
+      const sceneId = key[key.length - 1] as string;
+      chapterScenes.push({ rank, sceneId });
+    }
+
+    for (const { sceneId } of chapterScenes) {
+      const newRank = lastBookRank ? rankAfter(lastBookRank) : rankInitial();
+      lastBookRank = newRank;
+
+      const sceneEntityKey = sceneKey(userId, seriesId, bookId, sceneId);
+      const sceneEntry = await kv.get<Scene>(sceneEntityKey);
+      if (!sceneEntry.value) continue;
+
+      const updatedScene: Scene = {
+        ...sceneEntry.value,
+        chapterId: undefined,
+        rank: newRank,
+        updatedAt: Date.now(),
+      };
+
+      // Find the chapterSceneOrder entry key for this scene
+      let chapterSceneOrderEntryKey: Deno.KvKey | null = null;
+      for await (
+        const entry of kv.list({
+          prefix: ["yawt", "chapterSceneOrder", userId, seriesId, bookId, chapterId],
+        })
+      ) {
+        const entrySceneId = entry.key[entry.key.length - 1] as string;
+        if (entrySceneId === sceneId) {
+          chapterSceneOrderEntryKey = entry.key;
+          break;
+        }
+      }
+
+      const op = kv.atomic()
+        .set(sceneEntityKey, updatedScene)
+        .set(bookItemOrderKey(userId, seriesId, bookId, newRank), {
+          type: "scene" as const,
+          id: sceneId,
+        });
+
+      if (chapterSceneOrderEntryKey) {
+        op.delete(chapterSceneOrderEntryKey);
+      }
+
+      await op.commit();
+      scenesFlattened++;
+    }
+
+    // Delete the chapter entity and its bookItemOrder entry
+    let chapterOrderKey: Deno.KvKey | null = null;
+    for await (
+      const entry of kv.list<BookItem>({
+        prefix: ["yawt", "bookItemOrder", userId, seriesId, bookId],
+      })
+    ) {
+      if (entry.value?.type === "chapter" && entry.value.id === chapterId) {
+        chapterOrderKey = entry.key;
+        break;
+      }
+    }
+
+    const deleteOp = kv.atomic().delete(chapterKey(userId, seriesId, bookId, chapterId));
+    if (chapterOrderKey) deleteOp.delete(chapterOrderKey);
+    await deleteOp.commit();
+  }
+
+  // Update the book entity
+  const updatedBook: Book = {
+    ...book,
+    hasChapters: false,
+    updatedAt: Date.now(),
+  };
+  await kv.set(bookEntityKey, updatedBook);
+
+  return json({ book: updatedBook, scenesFlattened, chaptersRemoved }, { status: 200 });
+}
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -135,6 +266,40 @@ export const handler: Handlers = {
     }
 
     return json({ book: updated }, { status: 200 });
+  },
+
+  async PATCH(req, ctx) {
+    const userOrRes = await requireUser(req);
+    if (userOrRes instanceof Response) return userOrRes;
+    const user = userOrRes;
+    const { seriesId, bookId } = ctx.params;
+
+    const key = bookKey(user.id, seriesId, bookId);
+    const entry = await kv.get<Book>(key);
+    if (!entry.value) return notFound("Book not found");
+
+    const bodyOrRes = await readJson(req);
+    if (bodyOrRes instanceof Response) return bodyOrRes;
+    const body = bodyOrRes as Record<string, unknown>;
+
+    if (typeof body.hasChapters !== "boolean") {
+      return badRequest("hasChapters must be a boolean");
+    }
+
+    const currentHasChapters = entry.value.hasChapters !== false;
+    const nextHasChapters = body.hasChapters as boolean;
+
+    if (currentHasChapters === nextHasChapters) {
+      return json({ book: entry.value, scenesFlattened: 0, chaptersRemoved: 0 }, { status: 200 });
+    }
+
+    if (!nextHasChapters) {
+      return await flattenChapters(kv, user.id, seriesId, bookId, entry.value, key);
+    } else {
+      const updated: Book = { ...entry.value, hasChapters: true, updatedAt: Date.now() };
+      await kv.set(key, updated);
+      return json({ book: updated, scenesFlattened: 0, chaptersRemoved: 0 }, { status: 200 });
+    }
   },
 
   async DELETE(req, ctx) {

--- a/routes/api/series/[seriesId]/books/[bookId]/chapters.ts
+++ b/routes/api/series/[seriesId]/books/[bookId]/chapters.ts
@@ -57,6 +57,14 @@ export const handler: Handlers = {
     const book = await kv.get(bookKey(user.id, seriesId, bookId));
     if (!book.value) return notFound("Book not found");
 
+    const bookData = book.value as import("@utils/story/types.ts").Book;
+    if (bookData.hasChapters === false) {
+      return json(
+        { error: "This book does not use chapters. Enable chapters in book settings first." },
+        { status: 409 },
+      );
+    }
+
     const bodyOrRes = await readJson(req);
     if (bodyOrRes instanceof Response) return bodyOrRes;
     const body = bodyOrRes as Record<string, unknown>;

--- a/routes/api/series/[seriesId]/books/[bookId]/scenes.ts
+++ b/routes/api/series/[seriesId]/books/[bookId]/scenes.ts
@@ -58,6 +58,14 @@ export const handler: Handlers = {
     const book = await kv.get(bookKey(user.id, seriesId, bookId));
     if (!book.value) return notFound("Book not found");
 
+    const bookData = book.value as import("@utils/story/types.ts").Book;
+    if (bookData.hasChapters !== false) {
+      return json(
+        { error: "This book uses chapters. Add scenes within a chapter instead." },
+        { status: 409 },
+      );
+    }
+
     const bodyOrRes = await readJson(req);
     if (bodyOrRes instanceof Response) return bodyOrRes;
     const body = bodyOrRes as Record<string, unknown>;

--- a/routes/api/series/[seriesId]/books/[bookId]/scenes.ts
+++ b/routes/api/series/[seriesId]/books/[bookId]/scenes.ts
@@ -22,7 +22,7 @@ export const handler: Handlers = {
     const book = await kv.get(bookKey(user.id, seriesId, bookId));
     if (!book.value) return notFound("Book not found");
 
-    // Get book-level scenes from the unified book item order
+    // Collect all scene IDs: book-level scenes from bookItemOrder
     const sceneIds: string[] = [];
     for await (
       const entry of kv.list<BookItem>({
@@ -33,6 +33,18 @@ export const handler: Handlers = {
       if (item && item.type === "scene") {
         sceneIds.push(item.id);
       }
+    }
+
+    // Also collect chapter scenes from chapterSceneOrder
+    for await (
+      const entry of kv.list({
+        prefix: ["yawt", "chapterSceneOrder", user.id, seriesId, bookId],
+      })
+    ) {
+      const key = entry.key as unknown[];
+      // key shape: ["yawt", "chapterSceneOrder", userId, seriesId, bookId, chapterId, rank, sceneId]
+      const sceneId = key[key.length - 1];
+      if (typeof sceneId === "string") sceneIds.push(sceneId);
     }
 
     const scenes: Scene[] = [];

--- a/routes/series/[seriesId]/books/[bookId].tsx
+++ b/routes/series/[seriesId]/books/[bookId].tsx
@@ -456,23 +456,27 @@ export default function BookDetail({ data }: PageProps<Data>) {
                   <summary class="btn btn-sm">New</summary>
                   <div class="dropdown-content z-10 card card-compact bg-base-100 shadow w-80">
                     <div class="card-body">
-                      <form method="POST" class="grid gap-2">
-                        <input
-                          type="hidden"
-                          name="action"
-                          value="createChapter"
-                        />
-                        <input
-                          class="input input-bordered input-sm"
-                          name="title"
-                          placeholder="Chapter title"
-                          required
-                        />
-                        <button class="btn btn-primary btn-sm" type="submit">
-                          Create Chapter
-                        </button>
-                      </form>
-                      <div class="divider my-1">OR</div>
+                      {book.hasChapters !== false && (
+                        <>
+                          <form method="POST" class="grid gap-2">
+                            <input
+                              type="hidden"
+                              name="action"
+                              value="createChapter"
+                            />
+                            <input
+                              class="input input-bordered input-sm"
+                              name="title"
+                              placeholder="Chapter title"
+                              required
+                            />
+                            <button class="btn btn-primary btn-sm" type="submit">
+                              Create Chapter
+                            </button>
+                          </form>
+                          <div class="divider my-1">OR</div>
+                        </>
+                      )}
                       <form method="POST" class="grid gap-2">
                         <input
                           type="hidden"
@@ -510,6 +514,7 @@ export default function BookDetail({ data }: PageProps<Data>) {
                     chapters={chaptersWithScenes}
                     selectedSceneId={selectedScene?.id ?? null}
                     selectedChapterId={selectedChapterId}
+                    hasChapters={book.hasChapters !== false}
                   />
                 )}
             </div>

--- a/routes/series/[seriesId]/books/[bookId].tsx
+++ b/routes/series/[seriesId]/books/[bookId].tsx
@@ -204,6 +204,10 @@ export const handler: Handlers<Data> = {
     if (!bookRes.value) return new Response("Book not found", { status: 404 });
 
     if (action === "createChapter") {
+      if (bookRes.value.hasChapters === false) {
+        return new Response("Chapters are disabled for this book", { status: 409 });
+      }
+
       const title = String(form.get("title") ?? "").trim() ||
         "Untitled chapter";
 
@@ -256,6 +260,11 @@ export const handler: Handlers<Data> = {
     if (action === "createScene") {
       const title = String(form.get("title") ?? "").trim() || "Untitled scene";
       const chapterId = String(form.get("chapterId") ?? "").trim() || undefined;
+
+      // Guard: book-level scenes are only allowed when hasChapters is false
+      if (!chapterId && bookRes.value.hasChapters !== false) {
+        return new Response("Book-level scenes are not allowed when chapters are enabled", { status: 409 });
+      }
 
       let lastRank: string | undefined;
 

--- a/scripts/migrate-chapters-toggle.ts
+++ b/scripts/migrate-chapters-toggle.ts
@@ -65,9 +65,30 @@ interface Chapter {
   updatedAt: number;
 }
 
-function rankInitial(): string { return "m"; }
-function rankBefore(rank: string): string { return rank + "0"; }
-function rankAfter(rank: string): string { return rank + "z"; }
+const RANK_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function rankBetween(a: string | null, b: string | null): string {
+  let prefix = "";
+  let i = 0;
+  while (true) {
+    const aIndex = a != null && i < a.length ? RANK_ALPHABET.indexOf(a[i]) : 0;
+    const bIndex = b == null
+      ? RANK_ALPHABET.length - 1
+      : i < b.length
+      ? RANK_ALPHABET.indexOf(b[i])
+      : RANK_ALPHABET.length - 1;
+    if (bIndex - aIndex > 1) {
+      const mid = Math.floor((aIndex + bIndex) / 2);
+      return prefix + RANK_ALPHABET[mid];
+    }
+    prefix += RANK_ALPHABET[aIndex];
+    i++;
+  }
+}
+
+function rankInitial(): string { return rankBetween(null, null); }
+function rankBefore(rank: string): string { return rankBetween(null, rank); }
+function rankAfter(rank: string): string { return rankBetween(rank, null); }
 
 const stats = {
   booksScanned: 0,

--- a/scripts/migrate-chapters-toggle.ts
+++ b/scripts/migrate-chapters-toggle.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env -S deno run --unstable-kv --allow-net --allow-read --allow-write
+
+/**
+ * Migration: backfill hasChapters on all books and fix hybrid books.
+ *
+ * A "hybrid book" has both chapters AND book-level scenes in bookItemOrder.
+ * Fix: create an "Uncategorized" chapter, move all book-level scenes into it.
+ *
+ * All books with ≥1 chapter → hasChapters = true
+ * All books with 0 chapters → hasChapters = false
+ *
+ * Usage:
+ *   deno run --unstable-kv --allow-net scripts/migrate-chapters-toggle.ts [--dry-run] [--user-id <id>]
+ */
+
+/// <reference lib="deno.unstable" />
+
+const kv = await Deno.openKv();
+const args = Deno.args;
+const dryRun = args.includes("--dry-run");
+const userIdArg = args.indexOf("--user-id");
+const targetUserId = userIdArg !== -1 ? Number(args[userIdArg + 1]) : undefined;
+
+if (dryRun) console.log("🔍 DRY RUN — no writes\n");
+else console.log("🚀 MIGRATION — writes enabled\n");
+
+interface Book {
+  id: string;
+  userId: number;
+  seriesId: string;
+  rank: string;
+  title: string;
+  hasChapters?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface BookItem {
+  type: "chapter" | "scene";
+  id: string;
+}
+
+interface Scene {
+  id: string;
+  userId: number;
+  seriesId: string;
+  bookId: string;
+  chapterId?: string;
+  rank: string;
+  text: string;
+  derived: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface Chapter {
+  id: string;
+  userId: number;
+  seriesId: string;
+  bookId: string;
+  rank: string;
+  title: string;
+  description?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function rankInitial(): string { return "m"; }
+function rankBefore(rank: string): string { return rank + "0"; }
+function rankAfter(rank: string): string { return rank + "z"; }
+
+const stats = {
+  booksScanned: 0,
+  booksAlreadyMigrated: 0,
+  booksSetTrue: 0,
+  booksSetFalse: 0,
+  hybridBooksFixed: 0,
+  scenesMovedToUncategorized: 0,
+  errors: [] as string[],
+};
+
+async function getAllBooks(): Promise<Book[]> {
+  const books: Book[] = [];
+  for await (const entry of kv.list<Book>({ prefix: ["yawt", "book"] })) {
+    const book = entry.value;
+    if (!book) continue;
+    if (targetUserId !== undefined && book.userId !== targetUserId) continue;
+    books.push(book);
+  }
+  return books;
+}
+
+async function getBookItems(
+  userId: number,
+  seriesId: string,
+  bookId: string,
+): Promise<{ chapters: Array<{ rank: string; id: string }>; bookScenes: Array<{ rank: string; id: string }> }> {
+  const chapters: Array<{ rank: string; id: string }> = [];
+  const bookScenes: Array<{ rank: string; id: string }> = [];
+
+  for await (
+    const entry of kv.list<BookItem>({
+      prefix: ["yawt", "bookItemOrder", userId, seriesId, bookId],
+    })
+  ) {
+    const rank = entry.key[entry.key.length - 1] as string;
+    if (entry.value?.type === "chapter") chapters.push({ rank, id: entry.value.id });
+    if (entry.value?.type === "scene") bookScenes.push({ rank, id: entry.value.id });
+  }
+  return { chapters, bookScenes };
+}
+
+async function migrateBook(book: Book): Promise<void> {
+  stats.booksScanned++;
+
+  if (book.hasChapters !== undefined) {
+    stats.booksAlreadyMigrated++;
+    console.log(`  ✓ ${book.title} (${book.id}) — already migrated, skipping`);
+    return;
+  }
+
+  const { chapters, bookScenes } = await getBookItems(book.userId, book.seriesId, book.id);
+  const hasChapters = chapters.length > 0;
+  const isHybrid = hasChapters && bookScenes.length > 0;
+
+  console.log(
+    `  📖 ${book.title} (${book.id}) — chapters:${chapters.length} book-scenes:${bookScenes.length}${isHybrid ? " ⚠ HYBRID" : ""}`,
+  );
+
+  if (isHybrid) {
+    // Create "Uncategorized" chapter before all existing chapters
+    const firstChapterRank = chapters[0]?.rank ?? rankInitial();
+    const uncategorizedRank = rankBefore(firstChapterRank);
+    const uncategorizedId = crypto.randomUUID();
+    const now = Date.now();
+
+    const uncategorizedChapter: Chapter = {
+      id: uncategorizedId,
+      userId: book.userId,
+      seriesId: book.seriesId,
+      bookId: book.id,
+      rank: uncategorizedRank,
+      title: "Uncategorized",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    console.log(`    → Creating "Uncategorized" chapter ${uncategorizedId}`);
+
+    if (!dryRun) {
+      await kv
+        .atomic()
+        .set(["yawt", "chapter", book.userId, book.seriesId, book.id, uncategorizedId], uncategorizedChapter)
+        .set(["yawt", "bookItemOrder", book.userId, book.seriesId, book.id, uncategorizedRank], {
+          type: "chapter",
+          id: uncategorizedId,
+        })
+        .commit();
+    }
+
+    // Move each book-level scene into the Uncategorized chapter
+    let sceneRank = rankInitial();
+    for (const { rank: bookRank, id: sceneId } of bookScenes) {
+      console.log(`    → Moving scene ${sceneId} into Uncategorized`);
+
+      const sceneEntityKey = ["yawt", "scene", book.userId, book.seriesId, book.id, sceneId];
+      const sceneEntry = await kv.get<Scene>(sceneEntityKey);
+      if (!sceneEntry.value) {
+        stats.errors.push(`Scene ${sceneId} not found`);
+        continue;
+      }
+
+      const updatedScene: Scene = {
+        ...sceneEntry.value,
+        chapterId: uncategorizedId,
+        rank: sceneRank,
+        updatedAt: Date.now(),
+      };
+
+      if (!dryRun) {
+        await kv
+          .atomic()
+          .set(sceneEntityKey, updatedScene)
+          .set(
+            ["yawt", "chapterSceneOrder", book.userId, book.seriesId, book.id, uncategorizedId, sceneRank, sceneId],
+            1,
+          )
+          .delete(["yawt", "bookItemOrder", book.userId, book.seriesId, book.id, bookRank])
+          .commit();
+      }
+
+      sceneRank = rankAfter(sceneRank);
+      stats.scenesMovedToUncategorized++;
+    }
+
+    stats.hybridBooksFixed++;
+  }
+
+  // Set hasChapters on the book entity
+  const updatedBook: Book = {
+    ...book,
+    hasChapters,
+    updatedAt: Date.now(),
+  };
+
+  console.log(`    → Setting hasChapters=${hasChapters}`);
+
+  if (!dryRun) {
+    await kv.set(["yawt", "book", book.userId, book.seriesId, book.id], updatedBook);
+  }
+
+  if (hasChapters) stats.booksSetTrue++;
+  else stats.booksSetFalse++;
+}
+
+async function main(): Promise<void> {
+  console.log("═".repeat(60));
+  console.log("CHAPTERS TOGGLE MIGRATION");
+  console.log("═".repeat(60) + "\n");
+
+  const books = await getAllBooks();
+  console.log(`Found ${books.length} books to process\n`);
+
+  for (const book of books) {
+    try {
+      await migrateBook(book);
+    } catch (err) {
+      stats.errors.push(`Book ${book.id}: ${String(err)}`);
+      console.error(`  ✗ Error on book ${book.id}:`, err);
+    }
+  }
+
+  console.log("\n" + "═".repeat(60));
+  console.log("SUMMARY");
+  console.log("═".repeat(60));
+  console.log(`Books scanned:            ${stats.booksScanned}`);
+  console.log(`Already migrated:         ${stats.booksAlreadyMigrated}`);
+  console.log(`Set hasChapters=true:     ${stats.booksSetTrue}`);
+  console.log(`Set hasChapters=false:    ${stats.booksSetFalse}`);
+  console.log(`Hybrid books fixed:       ${stats.hybridBooksFixed}`);
+  console.log(`Scenes moved to Uncateg.: ${stats.scenesMovedToUncategorized}`);
+  if (stats.errors.length) {
+    console.log(`\n⚠ Errors (${stats.errors.length}):`);
+    for (const e of stats.errors) console.log(`  - ${e}`);
+  } else {
+    console.log(`\n✅ No errors`);
+  }
+
+  if (dryRun) console.log("\n💡 Run without --dry-run to apply changes.");
+  else console.log("\n✅ Migration complete!");
+
+  kv.close();
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  kv.close();
+  Deno.exit(1);
+});

--- a/utils/story/types.ts
+++ b/utils/story/types.ts
@@ -26,6 +26,7 @@ export interface Book {
   publishDate?: string;
   isbn?: string;
   coverImage?: AssetImage;
+  hasChapters: boolean;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Summary

- Adds `hasChapters: boolean` to `Book` — enforced at the API layer (409 if violated). New books default to chapters enabled.
- Atomic flatten operation when toggling chapters off: all chapter scenes moved to book level, chapters deleted, `hasChapters: false` written last.
- Redesigned `HierarchicalSceneList` as a two-mode sidebar: **Navigation mode** (full accordion with drag handles) and **Focus mode** (44px strip of chapter/scene number pills, auto-triggered by editor textarea focus, hover to peek).
- Book settings page gains an Organization card with toggle + destructive confirmation modal (chapter count, explicit confirm button).
- Create book form gains `hasChapters` toggle defaulting to on.
- Migration script (`scripts/migrate-chapters-toggle.ts`) backfills `hasChapters` on existing books and fixes hybrid books by creating an "Uncategorized" chapter.
- Breadcrumb fades to 20% opacity in focus mode; 409 errors surface as toast notifications.

## Test Plan

- [ ] Create a book with chapters enabled (default) — confirm chapter UI appears, book-level scene creation blocked
- [ ] Create a book with chapters disabled — confirm no chapter UI, chapter creation returns 409
- [ ] Add chapters and scenes, then toggle chapters off in settings — confirm modal shows correct chapter count, flatten is atomic, no scenes lost
- [ ] Toggle chapters back on — immediate, no modal, no data changes
- [ ] Click into editor textarea — confirm sidebar narrows to pill strip; hover to peek; blur to return
- [ ] Run `scripts/migrate-chapters-toggle.ts --dry-run` on local data — verify output looks correct before running live